### PR TITLE
feat(loader): support custom font paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Remove dependency of fontconfig and freetype lib
 - Add `-vv` option to show font file location and face index
 - ASCII mode render result now not narrow (Issue [#61](https://github.com/7sDream/fontfor/issues/61), fixed by PR [#63](https://github.com/7sDream/fontfor/pull/63))
+- Support custom font paths (Issue [#62](https://github.com/7sDream/fontfor/issues/62))
 - Now release contains ia32/x64/arm64 binary for Windows
 - Now release contains x64/arm64 binary for macOS
 - Now release contains x64/arm64/armhf binary Linux

--- a/src/args.rs
+++ b/src/args.rs
@@ -16,6 +16,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use std::path::PathBuf;
+
 use clap::Parser;
 
 use super::one_char::OneChar;
@@ -35,6 +37,11 @@ pub struct Args {
     /// enable this mode will disable the --preview/-p and ignore --verbose/-v option
     #[arg(short, long)]
     pub tui: bool,
+
+    /// Also load fonts in a custom path.
+    /// This arg can be provided multiple times.
+    #[arg(short = 'I', long = "include", name = "PATH", action = clap::ArgAction::Append)]
+    pub custom_font_paths: Vec<PathBuf>,
 
     /// The character
     #[arg(name = "CHAR")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,8 +38,9 @@ use preview::{browser::ServerBuilder as PreviewServerBuilder, terminal::ui::UI};
 fn main() {
     let argument = args::get();
 
-    let font_set = loader::faces_contains(argument.char.0);
+    loader::init(&argument.custom_font_paths);
 
+    let font_set = loader::query(argument.char.0);
     let families = family::group_by_family_sort_by_name(&font_set);
 
     if families.is_empty() {

--- a/src/preview/terminal/ui/state.rs
+++ b/src/preview/terminal/ui/state.rs
@@ -27,7 +27,7 @@ use tui::widgets::ListState;
 use super::cache::{CacheKey, GlyphCache, GlyphCanvasShape, RenderType, CHAR_RENDERS, MONO_RENDER};
 use crate::{
     family::Family,
-    loader::{FaceInfo, DATABASE},
+    loader::{self, FaceInfo},
     preview::terminal::{render::Render, ui::cache::GlyphParagraph},
     rasterizer::{Bitmap, Rasterizer},
 };
@@ -105,14 +105,14 @@ impl<'a> State<'a> {
             None
         };
 
-        DATABASE
+        loader::database()
             .with_face_data(info.id, |data, index| -> Option<Bitmap> {
                 let mut r = Rasterizer::new(data, index).ok()?;
                 r.set_pixel_height(height);
                 if let Some(scale) = scale {
                     r.set_hscale(scale);
                 }
-                r.rasterize(info.gid.0)
+                r.rasterize(info.gid)
             })
             .ok_or("Can't read this font file")?
             .ok_or("Can't get glyph from this font")


### PR DESCRIPTION
Add `-I`/`--include` option to add custom font paths.

Fixes #62.