### PR TITLE
Fix build on Rust 1.75

### DIFF
--- a/src/rasterizer/mod.rs
+++ b/src/rasterizer/mod.rs
@@ -20,7 +20,7 @@ mod bitmap;
 
 use ab_glyph::{Font, FontRef, GlyphId, InvalidFont, PxScale};
 
-pub use self::bitmap::{Bitmap, Metrics};
+pub use self::bitmap::Bitmap;
 
 pub struct Rasterizer<'a> {
     face: FontRef<'a>,


### PR DESCRIPTION
This patch removes an unused import of `pub use self::bitmap::Metrics` that breaks the build on current (1.75) versions of rustc due to the `#![deny(warnings)]` directive specified in `main.rs`.

This lint breaks the build of `FontFor` in Nixpkgs (unstable):
Failed Nixpkgs CI job: https://hydra.nixos.org/build/245712787
...and the according log: https://hydra.nixos.org/build/245712787/nixlog/5

```
...
   Compiling thiserror-impl v1.0.50
   Compiling clap_derive v4.4.7
   Compiling strum v0.25.0
   Compiling ratatui v0.24.0
   Compiling clap v4.4.8
   Compiling fontfor v0.4.1 (/build/source)
error: unused import: `Metrics`
  --> src/rasterizer/mod.rs:23:32
   |
23 | pub use self::bitmap::{Bitmap, Metrics};
   |                                ^^^^^^^
   |
note: the lint level is defined here
  --> src/main.rs:20:9
   |
20 | #![deny(warnings)]
   |         ^^^^^^^^
   = note: `#[deny(unused_imports)]` implied by `#[deny(warnings)]`
```
