### PR TITLE
feat: add font list filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased
 
+- Add `-f` option to filter font list by family name
+- Add a search box in TUI mode to change filter word
 - Remove `#[deny(warnings)]` in source code, add it in CI
-- Fix build for comming Rust 1.79 new lints
+- Fix build for upcomming Rust 1.79 new lints
 - Update deps
 
 ## 0.4.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
  "memmap2",
  "slotmap",
  "tinyvec",
- "ttf-parser",
+ "ttf-parser 0.20.0",
 ]
 
 [[package]]
@@ -289,10 +289,18 @@ dependencies = [
  "httparse",
  "log",
  "once_cell",
+ "range-set-blaze",
  "ratatui",
  "thiserror",
- "ttf-parser",
+ "ttf-parser 0.21.0",
+ "tui-input",
 ]
+
+[[package]]
+name = "gen_ops"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "304de19db7028420975a296ab0fcbbc8e69438c4ed254a1e41e2a7f37d5f0e0a"
 
 [[package]]
 name = "grid"
@@ -426,6 +434,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,7 +463,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4586edfe4c648c71797a74c84bacb32b52b212eff5dfe2bb9f2c599844023e7"
 dependencies = [
- "ttf-parser",
+ "ttf-parser 0.20.0",
 ]
 
 [[package]]
@@ -485,6 +511,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "range-set-blaze"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8421b5d459262eabbe49048d362897ff3e3830b44eac6cfe341d6acb2f0f13d2"
+dependencies = [
+ "gen_ops",
+ "itertools",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -732,6 +770,22 @@ name = "ttf-parser"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
+
+[[package]]
+name = "ttf-parser"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb71ffab0ca84cecd986dd52e873c8d0b013f3d5d9ce25a6f7d0513ed933d562"
+
+[[package]]
+name = "tui-input"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3e785f863a3af4c800a2a669d0b64c879b538738e352607e2624d03f868dc01"
+dependencies = [
+ "crossterm",
+ "unicode-width",
+]
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,10 @@ clap = { version = "4.4", features = ["derive", "unicode", "wrap_help"] }
 fontdb = "0.16"
 
 # Font parser
-ttf-parser = "0.20"
+ttf-parser = "0.21"
+
+# Filter fonts
+range-set-blaze = "0.1.16"
 
 # Font rasterizer
 # see https://gist.github.com/7sDream/0bb194be42b8cb1f1926ca12151c8d76 for alternatives.
@@ -39,6 +42,9 @@ ratatui = "0.26"
 
 # Terminal events
 crossterm = "0.27"
+
+# Input widget for filter in TUI
+tui-input = "0.8.0"
 
 # Home-made singel thread HTTP server for preview fonts in browser.
 # Alternative: output a html file into temp dir and open it

--- a/src/args.rs
+++ b/src/args.rs
@@ -18,11 +18,18 @@
 
 use std::path::PathBuf;
 
-use clap::Parser;
+use clap::{
+    builder::{NonEmptyStringValueParser, TypedValueParser},
+    Parser,
+};
 
 use super::one_char::OneChar;
 
-#[derive(Debug, clap::Parser)]
+fn no_newline_string_parser() -> impl TypedValueParser {
+    NonEmptyStringValueParser::new().map(|s| s.replace(['\r', '\n'], ""))
+}
+
+#[derive(Debug, Parser)]
 #[command(author, version, about, arg_required_else_help(true))]
 pub struct Args {
     /// Verbose mode, -v show all font styles, -vv adds font file and face index
@@ -46,6 +53,10 @@ pub struct Args {
     /// This arg can be provided multiple times.
     #[arg(short = 'I', long = "include", name = "PATH", action = clap::ArgAction::Append)]
     pub custom_font_paths: Vec<PathBuf>,
+
+    /// Only show fonts whose family name contains the filter string
+    #[arg(short = 'f', long = "filter", name = "FILTER", value_parser = no_newline_string_parser())]
+    pub filter: Option<String>,
 
     /// The character
     #[arg(name = "CHAR")]

--- a/src/family.rs
+++ b/src/family.rs
@@ -18,6 +18,8 @@
 
 use std::collections::HashMap;
 
+use range_set_blaze::RangeSetBlaze;
+
 use super::loader::FaceInfo;
 
 pub struct Family<'a> {
@@ -64,4 +66,128 @@ pub fn group_by_family_sort_by_name(faces: &[FaceInfo]) -> Vec<Family<'_>> {
     }
 
     families
+}
+
+pub struct FilteredFamilies<'a> {
+    data: Vec<Family<'a>>,
+    names: Vec<String>,
+    keyword: String,
+    filtered: RangeSetBlaze<usize>,
+}
+
+#[derive(Clone)]
+pub struct FilteredFamiliesIter<'f, 'a> {
+    data: &'f [Family<'a>],
+    range: range_set_blaze::Iter<usize, range_set_blaze::RangesIter<'f, usize>>,
+}
+
+impl<'f, 'a: 'f> FilteredFamiliesIter<'f, 'a> {
+    pub fn with_index(self) -> FilteredFamiliesWithIndexIter<'f, 'a> {
+        FilteredFamiliesWithIndexIter(self)
+    }
+}
+
+impl<'f, 'a: 'f> Iterator for FilteredFamiliesIter<'f, 'a> {
+    type Item = &'f Family<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.range.next().map(|i| &self.data[i])
+    }
+}
+
+pub struct FilteredFamiliesWithIndexIter<'f, 'a>(FilteredFamiliesIter<'f, 'a>);
+
+impl<'f, 'a: 'f> Iterator for FilteredFamiliesWithIndexIter<'f, 'a> {
+    type Item = (usize, &'f Family<'a>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.range.next().map(|i| (i, &self.0.data[i]))
+    }
+}
+
+impl<'a> FilteredFamilies<'a> {
+    pub fn new(families: Vec<Family<'a>>, keyword: String) -> Self {
+        let names = families.iter().map(|f| f.name.to_lowercase()).collect();
+        let mut ret = Self {
+            data: families,
+            names,
+            keyword: keyword.to_lowercase(),
+            filtered: RangeSetBlaze::new(),
+        };
+        ret.filter(true);
+        ret
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    fn full_indices(&self) -> RangeSetBlaze<usize> {
+        if !self.data.is_empty() {
+            RangeSetBlaze::from_iter(&[0..=self.data.len() - 1])
+        } else {
+            RangeSetBlaze::new()
+        }
+    }
+
+    pub fn matched_indices(&self) -> &RangeSetBlaze<usize> {
+        &self.filtered
+    }
+
+    pub fn data(&self) -> &[Family<'a>] {
+        &self.data
+    }
+
+    pub fn matched(&self) -> FilteredFamiliesIter<'_, 'a> {
+        FilteredFamiliesIter {
+            data: &self.data,
+            range: self.matched_indices().iter(),
+        }
+    }
+
+    fn unmatched_indices(&self) -> RangeSetBlaze<usize> {
+        &self.full_indices() - self.matched_indices()
+    }
+
+    fn retain(rs: &mut RangeSetBlaze<usize>, data: &[String], keyword: &str) {
+        if !keyword.is_empty() {
+            rs.retain(|i| data[*i].contains(keyword))
+        }
+    }
+
+    fn filter(&mut self, reset: bool) {
+        if reset {
+            self.filtered = self.full_indices()
+        }
+
+        Self::retain(&mut self.filtered, &self.names, &self.keyword)
+    }
+
+    pub fn keyword(&self) -> &str {
+        &self.keyword
+    }
+
+    pub fn change_keyword(&mut self, keyword: &str) {
+        let keyword = keyword.to_lowercase();
+
+        if self.keyword == keyword {
+            return;
+        }
+
+        if self.keyword.starts_with(&keyword) || self.keyword.ends_with(&keyword) {
+            // more loose, only search unmatched and append to matches
+            let mut unmatched = self.unmatched_indices();
+            self.keyword = keyword;
+            Self::retain(&mut unmatched, &self.names, &self.keyword);
+            self.filtered.append(&mut unmatched)
+        } else if keyword.starts_with(&keyword) || keyword.ends_with(&keyword) {
+            // more strict, search currents matches again
+            self.keyword = keyword;
+            self.filter(false);
+        } else {
+            // research all
+            self.keyword = keyword;
+            self.filter(true)
+        }
+    }
 }

--- a/src/preview/terminal/ui/cache.rs
+++ b/src/preview/terminal/ui/cache.rs
@@ -55,7 +55,7 @@ pub static MONO_RENDER: Lazy<MonoRender> = Lazy::new(MonoRender::default);
 
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct CacheKey {
-    pub index: usize,
+    pub index: (usize, usize),
     pub rt: RenderType,
     pub width: u32,
     pub height: u32,


### PR DESCRIPTION
This PR adds a filter option  `-f`/`--filter` in CLI, TUI mode also gets a input box to update the filter word.

The filter process is case-insenstive, and only cares about *family name*, not full name.

![image](https://github.com/7sDream/fontfor/assets/7822577/2e686526-8cdd-4c6b-aa69-a125dad4bde1)

Fixes #64.