### PR TITLE
docs: fix typos

### DIFF
--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -13,7 +13,7 @@ on:
       channel:
         type: string
         default: stable
-      artifict:
+      artifact:
         type: boolean
         default: true
 

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -20,4 +20,4 @@ jobs:
     with:
       name: fontfor
       channel: beta
-      artifict: false
+      artifact: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Add `-f` option to filter font list by family name, and a search box in TUI mode to change the filter word (Issue [#64](https://github.com/7sDream/fontfor/issues/64), PR [#71](https://github.com/7sDream/fontfor/pull/71))
 - Remove `#[deny(warnings)]` in source code, add it in CI (Issue [#70](https://github.com/7sDream/fontfor/issues/70))
-- Fix build for upcomming Rust 1.79 new lints
+- Fix build for upcoming Rust 1.79 new lints
 - Update deps
 
 ## 0.4.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ crossterm = "0.27"
 # Input widget for filter in TUI
 tui-input = "0.8.0"
 
-# Home-made singel thread HTTP server for preview fonts in browser.
+# Home-made single thread HTTP server for preview fonts in browser.
 # Alternative: output a html file into temp dir and open it
 httparse = "1.8"
 


### PR DESCRIPTION
Found via `typos --hidden --format brief`